### PR TITLE
FT: Upgrade web3js v4

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -36,7 +36,8 @@ ENV PATH "$PATH:/opt/geth-linux-amd64-1.12.0-e501b3b0"
 CMD ganache -v -h 0.0.0.0 \ 
     --account=\"$(cat run/secrets/test_acc1_priv_key),3000000000000000000000000000000000000000000\" \
     --account=\"$(cat run/secrets/test_acc2_priv_key),3000000000000000000000000000000000000000000\" \
-    --gasPrice 2000000000
+    --gasPrice 2000000000 \
+    --chain.chainId 1337
 
 # --------------------------------------------------------------------------------------------------------
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -33,11 +33,12 @@ RUN curl -fsSL https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1
 
 ENV PATH "$PATH:/opt/geth-linux-amd64-1.12.0-e501b3b0"
 
-CMD ganache -v -h 0.0.0.0 \ 
+CMD ganache --logging.verbose --logging.debug --chain.vmErrorsOnRPCResponse -h 0.0.0.0 \ 
     --account=\"$(cat run/secrets/test_acc1_priv_key),3000000000000000000000000000000000000000000\" \
     --account=\"$(cat run/secrets/test_acc2_priv_key),3000000000000000000000000000000000000000000\" \
     --gasPrice 2000000000 \
-    --chain.chainId 1337
+    --chain.chainId 1337 \
+    --database.dbPath "/opt/db"
 
 # --------------------------------------------------------------------------------------------------------
 

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,9 +10,14 @@ services:
     secrets:
       - test_acc1_priv_key
       - test_acc2_priv_key
+    volumes:
+      - ganachedb:/opt/db
 
 secrets:
   test_acc1_priv_key:
     file: '../../eva-investments-resources/accounts/.secrets/test_acc1_priv_key'
   test_acc2_priv_key:
     file: '../../eva-investments-resources/accounts/.secrets/test_acc2_priv_key'
+
+volumes:
+  ganachedb:

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/bn.js": "^5.1.1",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
@@ -61,9 +62,9 @@
     "cli": "file:src/libs/cli",
     "concurrently": "^7.0.0",
     "dotenv": "^10.0.0",
+    "logger": "file:src/libs/logger",
     "swagger-client-mapper": "file:src/libs/swagger-client-mapper",
-    "worker-pool": "file:src/libs/worker-pool",
-    "logger": "file:src/libs/logger"
+    "worker-pool": "file:src/libs/worker-pool"
   },
   "jest": {
     "preset": "ts-jest",

--- a/server/src/appContext.ts
+++ b/server/src/appContext.ts
@@ -2,8 +2,7 @@ import {
   initBlockchainCommunication,
   initCli,
   Web3Extension,
-  Socket,
-  provider,
+  Web3BaseProvider,
   getNonceTracker,
   logInfo
 } from './deps';
@@ -90,7 +89,7 @@ async function initServices(): Promise<void> {
 
 async function initMutexesForAccounts(web3: Web3Extension): Promise<void> {
   const nonceTracker = getNonceTracker();
-  const chainId = web3.chainId;
+  const chainId = web3.chainId.toString();
   const promises = getAccountsRepository()
     .getAccounts(chainId)
     .map((account) => account.address)
@@ -121,10 +120,9 @@ export function getBlocksRepository(): BlocksRepository {
 // so, if you pass params for a case where the singleton already exists,
 // the params are ignored and you get the singleton as is (not ideal, but should suffice for now)
 export async function getAsyncWeb3Extension(
-  chainId: number,
+  chainId: string,
   automaticProviders = true,
-  provider?: provider,
-  socket?: Socket,
+  provider?: Web3BaseProvider,
   proxyCallbacksFilePath?: string
 ): Promise<Web3Extension> {
   const { web3Extensions } = await getAsyncAppContext();
@@ -135,7 +133,6 @@ export async function getAsyncWeb3Extension(
       chainId,
       automaticProviders,
       provider,
-      socket,
       proxyCallbacksFilePath
     );
 
@@ -147,7 +144,7 @@ export async function getAsyncWeb3Extension(
   return web3Extension;
 }
 
-export function getWeb3Extension(chainId: number): Web3Extension {
+export function getWeb3Extension(chainId: string): Web3Extension {
   const { web3Extensions } = getAppContext();
 
   const web3Extension = web3Extensions[chainId];

--- a/server/src/appContext.ts
+++ b/server/src/appContext.ts
@@ -42,6 +42,7 @@ const appContext: AppContext = {
 let appContextReady = false;
 
 export async function initAppContext() {
+  overrideDefaults();
   await initServices();
 
   if (appContext.externalDeps == null) {
@@ -67,6 +68,12 @@ function getAppContext(): AppContext {
   }
 
   return appContext;
+}
+
+function overrideDefaults() {
+  (BigInt.prototype as any).toJSON = function () {
+    return this.toString();
+  };
 }
 
 // Init all cliAdapters

--- a/server/src/arbitrage/domain/services/arbitrageService.ts
+++ b/server/src/arbitrage/domain/services/arbitrageService.ts
@@ -5,7 +5,7 @@ export const startArbitrage = async (
   path: ArbitragePool[],
   arbitrageParams: ArbitrageParams,
   accountAddress: string,
-  chainId: number
+  chainId: string
 ): Promise<string> => {
   return await getExternalDeps().startArbitrage(
     path,

--- a/server/src/arbitrage/drivers/arbitrageCliAdapter.ts
+++ b/server/src/arbitrage/drivers/arbitrageCliAdapter.ts
@@ -19,7 +19,7 @@ import {
 type StartArbitrageParams = {
   pools: string;
   accountAddress: string;
-  chainId: number;
+  chainId: string;
   inputAmountsByToken: Dictionary<string>;
   outputAmountsByToken: Dictionary<string>;
   slippagePercentage: number;

--- a/server/src/chains/domain/entities/block.ts
+++ b/server/src/chains/domain/entities/block.ts
@@ -1,7 +1,7 @@
 export interface Block {
-  number: number;
-  baseFeePerGas: number;
-  gasLimit: number;
-  gasUsed: number;
+  number: bigint;
+  baseFeePerGas: bigint;
+  gasLimit: bigint;
+  gasUsed: bigint;
   transactionsHashes: string[];
 }

--- a/server/src/chains/domain/services/chainsService.ts
+++ b/server/src/chains/domain/services/chainsService.ts
@@ -1,6 +1,6 @@
 import { getChainsRepository } from '../../../appContext';
 
-export const getGasWrappedTokenAddress = (chaindId: number): string => {
+export const getGasWrappedTokenAddress = (chaindId: string): string => {
   const gasTokenAddress =
     getChainsRepository().getGasWrappedTokenAddress(chaindId);
 
@@ -12,7 +12,7 @@ export const getGasWrappedTokenAddress = (chaindId: number): string => {
   return gasTokenAddress;
 };
 
-export const getNativeTokenSymbol = (chaindId: number): string => {
+export const getNativeTokenSymbol = (chaindId: string): string => {
   const nativeTokenSymbol =
     getChainsRepository().getNativeTokenSymbol(chaindId);
 
@@ -22,7 +22,7 @@ export const getNativeTokenSymbol = (chaindId: number): string => {
   return nativeTokenSymbol;
 };
 
-export const getMempoolBlockAge = (chaindId: number): number => {
+export const getMempoolBlockAge = (chaindId: string): number => {
   const mempoolBlockAge = getChainsRepository().getMempoolBlockAge(chaindId);
 
   if (mempoolBlockAge == null) {

--- a/server/src/chains/domain/services/decodeInputService.ts
+++ b/server/src/chains/domain/services/decodeInputService.ts
@@ -19,13 +19,13 @@ type ContractABI = {
 };
 
 const abiByChainAndAddress: Dictionary<ContractABI> = {};
-const getABIByChainAndAddressKey = (chainId: number, address: string): string =>
+const getABIByChainAndAddressKey = (chainId: string, address: string): string =>
   chainId + address;
 
 // Only supports decoding function types
 export const decodeInput = (
   web3: Web3,
-  chainId: number,
+  chainId: string,
   address: string,
   input: string
 ): DecodedInput => {
@@ -63,7 +63,7 @@ export const decodeInput = (
 
 const getABIForChainAndAddress = (
   web3: Web3,
-  chainId: number,
+  chainId: string,
   address: string
 ): ContractABI => {
   const key = getABIByChainAndAddressKey(chainId, address);
@@ -93,7 +93,7 @@ const getABIForChainAndAddress = (
 
 const createAbiByChainAndAddress = (
   web3: Web3,
-  chainId: number,
+  chainId: string,
   address: string,
   callbackOnChange?: () => void
 ): ContractABI => {

--- a/server/src/chains/driven/data-sources/blocksMemoryAdapter.ts
+++ b/server/src/chains/driven/data-sources/blocksMemoryAdapter.ts
@@ -1,13 +1,13 @@
 import { Block } from '../../domain/entities/block';
 import { Dictionary } from '../../../types/types';
 import { BlocksRepository } from '../repositories/blocksRepository';
-import { BlockTransactionString } from 'web3-eth';
+import { GetBlockOutput } from '../../../deps';
 
 export class BlocksMemoryAdapter implements BlocksRepository {
   private static instance: BlocksMemoryAdapter;
 
-  private latestBlockByChainId: Dictionary<Block | { number: number }>;
-  private latestBlockNumberByChainId: Dictionary<number>;
+  private latestBlockByChainId: Dictionary<Block | { number: bigint }>;
+  private latestBlockNumberByChainId: Dictionary<bigint>;
 
   private constructor() {
     this.latestBlockByChainId = {};
@@ -21,26 +21,26 @@ export class BlocksMemoryAdapter implements BlocksRepository {
     return this.instance;
   }
 
-  getLatestBlockNumber(chainId: number): number | undefined {
+  getLatestBlockNumber(chainId: string): bigint | undefined {
     return this.latestBlockNumberByChainId[chainId];
   }
 
-  setLatestBlockNumber(chainId: number, blockNumber: number): void {
+  setLatestBlockNumber(chainId: string, blockNumber: bigint): void {
     this.latestBlockNumberByChainId[chainId] = blockNumber;
   }
 
-  getLatestBlock(chainId: number): Block | undefined {
+  getLatestBlock(chainId: string): Block | undefined {
     const block = this.latestBlockByChainId[chainId];
     return block ? (block as Block) : undefined;
   }
 
-  setLatestBlock(chainId: number, block: BlockTransactionString): void {
+  setLatestBlock(chainId: string, block: GetBlockOutput): void {
     this.latestBlockByChainId[chainId] = {
-      number: block.number,
-      baseFeePerGas: block.baseFeePerGas!,
-      gasLimit: block.gasLimit,
-      gasUsed: block.gasUsed,
-      transactionsHashes: block.transactions
+      number: block.number as bigint,
+      baseFeePerGas: block.baseFeePerGas! as bigint,
+      gasLimit: block.gasLimit as bigint,
+      gasUsed: block.gasUsed as bigint,
+      transactionsHashes: block.transactions as string[]
     };
   }
 }

--- a/server/src/chains/driven/data-sources/chainsFileAdapter.ts
+++ b/server/src/chains/driven/data-sources/chainsFileAdapter.ts
@@ -6,7 +6,7 @@ import { ROOT_PATH } from '../../../deps';
 const CHAINS_ENV_KEY = 'CHAINS';
 
 type ChainByChainId = {
-  chainId: number;
+  chainId: string;
   nativeTokenSymbol: string;
   gasWrappedTokenAddress: string;
   mempoolBlockAge: number;
@@ -26,7 +26,7 @@ export class ChainsFileAdapter implements ChainsRepository {
     return ChainsFileAdapter.instance;
   }
 
-  getGasWrappedTokenAddress(chainId: number): string | undefined {
+  getGasWrappedTokenAddress(chainId: string): string | undefined {
     const chains = getObjFromJson(
       CHAINS_ENV_KEY,
       ROOT_PATH,
@@ -38,7 +38,7 @@ export class ChainsFileAdapter implements ChainsRepository {
       ?.gasWrappedTokenAddress;
   }
 
-  getNativeTokenSymbol(chainId: number): string | undefined {
+  getNativeTokenSymbol(chainId: string): string | undefined {
     const chains = getObjFromJson(
       CHAINS_ENV_KEY,
       ROOT_PATH,
@@ -49,7 +49,7 @@ export class ChainsFileAdapter implements ChainsRepository {
     return chains.find((chain) => chain.chainId === chainId)?.nativeTokenSymbol;
   }
 
-  getMempoolBlockAge(chainId: number): number | undefined {
+  getMempoolBlockAge(chainId: string): number | undefined {
     const chains = getObjFromJson(
       CHAINS_ENV_KEY,
       ROOT_PATH,

--- a/server/src/chains/driven/data-sources/chainsFileAdapter.ts
+++ b/server/src/chains/driven/data-sources/chainsFileAdapter.ts
@@ -85,7 +85,12 @@ const isChainByChainId = (obj: any): boolean => {
   return (
     isType(
       obj,
-      ['chainId', 'nativeTokenSymbol', 'gasWrappedTokenAddress'],
+      [
+        'chainId',
+        'nativeTokenSymbol',
+        'gasWrappedTokenAddress',
+        'mempoolBlockAge'
+      ],
       []
     ) &&
     (obj as ChainByChainId).chainId != null &&

--- a/server/src/chains/driven/repositories/blocksRepository.ts
+++ b/server/src/chains/driven/repositories/blocksRepository.ts
@@ -1,9 +1,9 @@
 import { Block } from '../../domain/entities/block';
-import { BlockTransactionString } from '../../../deps';
+import { GetBlockOutput } from '../../../deps';
 
 export interface BlocksRepository {
-  getLatestBlockNumber(chainId: number): number | undefined;
-  setLatestBlockNumber(chainId: number, blockNumber: number): void;
-  getLatestBlock(chainId: number): Block | undefined;
-  setLatestBlock(chainId: number, block: BlockTransactionString): void;
+  getLatestBlockNumber(chainId: string): bigint | undefined;
+  setLatestBlockNumber(chainId: string, blockNumber: bigint): void;
+  getLatestBlock(chainId: string): Block | undefined;
+  setLatestBlock(chainId: string, block: GetBlockOutput): void;
 }

--- a/server/src/chains/driven/repositories/chainsRepository.ts
+++ b/server/src/chains/driven/repositories/chainsRepository.ts
@@ -1,5 +1,5 @@
 export interface ChainsRepository {
-  getGasWrappedTokenAddress(chainId: number): string | undefined;
-  getNativeTokenSymbol(chainId: number): string | undefined;
-  getMempoolBlockAge(chainId: number): number | undefined;
+  getGasWrappedTokenAddress(chainId: string): string | undefined;
+  getNativeTokenSymbol(chainId: string): string | undefined;
+  getMempoolBlockAge(chainId: string): number | undefined;
 }

--- a/server/src/contracts/domain/services/contractEventsService.ts
+++ b/server/src/contracts/domain/services/contractEventsService.ts
@@ -1,24 +1,26 @@
-import { EventData } from '../../../deps';
+import { Contract, ContractAbi, ContractEvents, EventLog } from '../../../deps';
 import { getWeb3Extension } from '../../../appContext';
 import { getContractByName } from './contractService';
 import { loadPrecompiledContract } from './deployContractService';
 
-export const getContractEvents = (
-  chainId: number,
-  eventName: string,
+export const getContractEvents = <Abi extends ContractAbi>(
+  chainId: string,
+  eventName: keyof ContractEvents<Abi>,
   contractName: string,
-  fromBlock: number
-): Promise<EventData[]> => {
+  fromBlock: bigint
+): Promise<EventLog[]> => {
   const contractData = getContractByName(chainId, contractName);
   const web3 = getWeb3Extension(chainId);
-  const contract = loadPrecompiledContract(
+  const contract: Contract<Abi> = loadPrecompiledContract(
     web3,
     contractData.compiledPath,
     contractData.address
   );
 
+  contract.events;
+
   return contract.getPastEvents(eventName, {
     fromBlock: fromBlock,
     toBlock: 'latest'
-  });
+  }) as Promise<EventLog[]>;
 };

--- a/server/src/contracts/domain/services/contractService.ts
+++ b/server/src/contracts/domain/services/contractService.ts
@@ -1,7 +1,7 @@
 import { readJsonFile } from '../../../utils/files';
 import { getContractsRepository } from '../../../appContext';
 import { ContractData } from '../entities/contract';
-import { Dictionary } from 'src/mod';
+import { Dictionary } from '../../../mod';
 
 const callbacksOnChange: Dictionary<() => void> = {};
 const getCallbacksOnChangeKey = (chainId: string, address: string) =>

--- a/server/src/contracts/domain/services/contractService.ts
+++ b/server/src/contracts/domain/services/contractService.ts
@@ -4,11 +4,11 @@ import { ContractData } from '../entities/contract';
 import { Dictionary } from 'src/mod';
 
 const callbacksOnChange: Dictionary<() => void> = {};
-const getCallbacksOnChangeKey = (chainId: number, address: string) =>
+const getCallbacksOnChangeKey = (chainId: string, address: string) =>
   chainId + address;
 
 export const getContractByName = (
-  chainId: number,
+  chainId: string,
   name: string,
   isCompiled = true
 ): ContractData => {
@@ -19,7 +19,7 @@ export const getContractByName = (
 };
 
 export const getContractByAddress = (
-  chainId: number,
+  chainId: string,
   address: string,
   callOnChange?: () => void,
   isCompiled = true
@@ -42,7 +42,7 @@ const validateContractPaths = (
 };
 
 const getCompiledContractByName = (
-  chainId: number,
+  chainId: string,
   name: string
 ): ContractData => {
   const contracts = getContractsRepository().getContractsData(chainId, {
@@ -59,7 +59,7 @@ const getCompiledContractByName = (
 };
 
 const getCompiledContractByAddress = (
-  chainId: number,
+  chainId: string,
   address: string,
   callOnChange?: () => void
 ): ContractData => {
@@ -81,7 +81,7 @@ const getCompiledContractByAddress = (
 };
 
 const registerCallbackOnChange = (
-  chainId: number,
+  chainId: string,
   address: string,
   callOnChange: () => void
 ) => {

--- a/server/src/contracts/domain/services/deployContractService.ts
+++ b/server/src/contracts/domain/services/deployContractService.ts
@@ -108,6 +108,7 @@ const _deployContract = async <Abi extends ContractAbi>(
     );
   }
 
+  // TODO: check _loadContract comment
   const contract = new web3.eth.Contract(abi);
   const contractTxEncoded = contract
     .deploy({
@@ -171,5 +172,9 @@ const _loadContract = <Abi extends ContractAbi>(
   abi: Abi,
   contractAddress: string
 ): Contract<Abi> => {
+  // TODO: Update web3js version to a version where contract initialization is no longer adding a listener on the requestmanager for the provider events
+  // warning: MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
+  // web3_subscription_manager.js -> listenToProviderEvents -> this.requestManager.provider.on
+  // this was fixed on version 2 (https://github.com/web3/web3.js/issues/1648) but potentially when migrating to version 4, they ignored everything in version 2 and 3
   return new web3.eth.Contract<Abi>(abi, contractAddress);
 };

--- a/server/src/contracts/domain/services/errors/contractContentMissingError.ts
+++ b/server/src/contracts/domain/services/errors/contractContentMissingError.ts
@@ -1,10 +1,12 @@
+import { ContractAbi } from '../../../../deps';
+
 class ContractContentMissingError extends Error {
   constructor(
     contractPath: string,
     contractName: string,
     contractJson: string,
     contractByteCode: string,
-    abi: []
+    abi: ContractAbi
   ) {
     super(
       `Could not load contract ${contractName} (found in ${contractPath}) successfully. 

--- a/server/src/contracts/domain/services/errors/transactionTimeoutError.ts
+++ b/server/src/contracts/domain/services/errors/transactionTimeoutError.ts
@@ -1,19 +1,17 @@
-import { BN } from '../../../../deps';
-
 export class TransactionTimeoutError extends Error {
-  private _nonce: number;
+  private _nonce: bigint;
   private _gasPriceInWei?: string;
-  private _maxPriorityFeePerGasInWei?: BN;
-  private _maxFeePerGasInWei?: BN;
-  private _gas: number;
+  private _maxPriorityFeePerGasInWei?: bigint;
+  private _maxFeePerGasInWei?: bigint;
+  private _gas: bigint;
 
   constructor(
     txHash: string | undefined,
-    nonce: number,
+    nonce: bigint,
     gasPriceInWei: string | undefined,
-    maxPriorityFeePerGasInWei: BN | undefined,
-    maxFeePerGasInWei: BN | undefined,
-    gas: number,
+    maxPriorityFeePerGasInWei: bigint | undefined,
+    maxFeePerGasInWei: bigint | undefined,
+    gas: bigint,
     timeout: number
   ) {
     super(

--- a/server/src/contracts/domain/services/transactionService.ts
+++ b/server/src/contracts/domain/services/transactionService.ts
@@ -6,14 +6,9 @@ import {
   EtherUnits,
   Web3,
   getNonceTracker,
-  logError,
   logDebug,
   logWarn,
-  wrapWithLogger,
-  Transaction,
-  TypedTransaction,
-  Address,
-  FeeMarketEIP1559Transaction
+  wrapWithLogger
 } from '../../../deps';
 import { Account } from '../../../wallets/domain/entities/accounts';
 import { TRANSACTION_TIMEOUT } from '../constants/contractConstants';

--- a/server/src/contracts/driven/data-sources/contractsConfigFileAdapter.ts
+++ b/server/src/contracts/driven/data-sources/contractsConfigFileAdapter.ts
@@ -12,7 +12,7 @@ import { unwatchFile, watchFile } from '../../../utils/filesystemWatcher';
 const CONTRACTS_ENV_KEY = 'CONTRACTS';
 
 type ContractsByChainId = {
-  chainId: number;
+  chainId: string;
   contracts: ContractData[];
 };
 
@@ -34,7 +34,7 @@ export class ContractsConfigFileAdapter implements ContractsRepository {
   }
 
   getContractsData(
-    chainId: number,
+    chainId: string,
     filter?: ContractDataFilter
   ): ContractData[] {
     try {

--- a/server/src/contracts/driven/repositories/contractsRepository.ts
+++ b/server/src/contracts/driven/repositories/contractsRepository.ts
@@ -9,7 +9,7 @@ export type ContractDataFilter = {
 
 export interface ContractsRepository {
   getContractsData(
-    chainId: number,
+    chainId: string,
     filter?: ContractDataFilter
   ): ContractData[];
 

--- a/server/src/contracts/drivers/contractsCliAdapter.ts
+++ b/server/src/contracts/drivers/contractsCliAdapter.ts
@@ -4,7 +4,7 @@ import {
   cliEntrypoint,
   getAllCliEntrypointsByCliAdapter,
   println,
-  Unit
+  EtherUnits
 } from '../../deps';
 import {
   CliConstants,
@@ -55,14 +55,14 @@ export class ContractsCliAdapter {
     description: ContractsCliConstants.CONTRACTS_DEPLOY_DESCRIPTION
   })
   async deployContract(
-    chainId: number,
+    chainId: string,
     contractPath: string,
     contractName: string,
     compiledContractPath: string,
     deployerAccountAddress: string,
     host: string,
-    gas: number,
-    ethereUnit: Unit,
+    gas: string,
+    ethereUnit: EtherUnits,
     gasPrice: string | undefined,
     maxPriorityFeePerGas: string | undefined,
     maxFeePerGas: string | undefined,
@@ -80,13 +80,11 @@ export class ContractsCliAdapter {
         compiledContractPath,
         deployerAccountAddress,
         host,
-        gas,
-        ethereUnit as Unit,
+        BigInt(gas),
+        ethereUnit,
         gasPrice,
-        maxPriorityFeePerGas
-          ? web3.utils.toBN(maxPriorityFeePerGas)
-          : undefined,
-        maxFeePerGas ? web3.utils.toBN(maxFeePerGas) : undefined,
+        maxPriorityFeePerGas ? BigInt(maxPriorityFeePerGas) : undefined,
+        maxFeePerGas ? BigInt(maxFeePerGas) : undefined,
         contractArgs
       );
       await println(`Deployed contract address: ${deployedContractAddress}`);

--- a/server/src/deps.ts
+++ b/server/src/deps.ts
@@ -36,7 +36,6 @@ export {
   GetBlockOutput,
   GetTransactionOutput,
   TypedTransaction,
-  Address,
   FeeMarketEIP1559Transaction,
   ContractAbi,
   ContractEvents,

--- a/server/src/deps.ts
+++ b/server/src/deps.ts
@@ -32,9 +32,15 @@ export { Web3 }; // without this, Web3 was undefined in certain tests
 export {
   initBlockchainCommunication,
   Web3Extension,
-  BlockHeader,
-  BlockTransactionString,
-  TransactionConfig,
+  BlockHeaderOutput,
+  GetBlockOutput,
+  GetTransactionOutput,
+  TypedTransaction,
+  Address,
+  FeeMarketEIP1559Transaction,
+  ContractAbi,
+  ContractEvents,
+  ContractConstructorArgs,
   Node,
   NodesConfigRepository,
   NodesRepository,
@@ -43,24 +49,24 @@ export {
   HttpNodeOptions,
   IpcNodeOptions,
   WsNodeOptions,
-  Subscription,
+  Web3Subscription,
   buildHttpNodeOptions,
   buildIpcNodeOptions,
   buildWsNodeOptions,
-  Unit,
+  EtherUnits,
   TransactionReceipt,
-  ContractSendMethod,
-  SignedTransaction,
+  SignTransactionResult,
   Contract,
   NonceTracker,
   getNonceTracker,
-  Socket,
-  provider,
+  Web3BaseProvider,
   nodeToProvider,
-  attemptImport
+  attemptImport,
+  HexString,
+  Web3EventMap
 } from 'blockchain-communication';
-export { Transaction } from 'web3-core';
-export { EventData } from 'web3-eth-contract';
+export { Transaction } from 'web3-types';
+export { EventLog } from 'web3-eth-contract';
 
 export {
   cliAdapter,

--- a/server/src/externalDeps.ts
+++ b/server/src/externalDeps.ts
@@ -23,7 +23,7 @@ export interface ExternalDeps {
     path: ArbitragePool[],
     arbitrageParams: ArbitrageParams,
     accountAddress: string,
-    chainId: number
+    chainId: string
   ) => Promise<string>;
   stopAllArbitrages: (force?: boolean) => Promise<void>;
   stopArbitrage: (arbitrageId: string, force?: boolean) => Promise<void>;

--- a/server/src/libs/blockchain-communication/deps.ts
+++ b/server/src/libs/blockchain-communication/deps.ts
@@ -1,21 +1,38 @@
 import { join as pathJoin } from 'path';
 import { readdirSync, readFileSync } from 'fs';
-import Web3 from 'web3';
+import { SocketConstructorOpts } from 'net';
+import { Web3 } from 'web3';
 import {
-  provider,
   TransactionReceipt,
-  SignedTransaction,
-  TransactionConfig
-} from 'web3-core';
-import { BlockHeader, BlockTransactionString } from 'web3-eth';
-import { Subscription } from 'web3-core-subscriptions';
+  Web3BaseProvider,
+  BlockHeaderOutput,
+  ContractAbi,
+  ContractEvents,
+  ContractConstructorArgs,
+  HexString
+} from 'web3-types';
+import {
+  SignTransactionResult,
+  TypedTransaction,
+  FeeMarketEIP1559Transaction
+} from 'web3-eth-accounts';
+import { Address } from 'web3-eth-accounts/lib/commonjs/tx/address';
+import { IpcProvider } from 'web3-providers-ipc';
 import HttpProvider from 'web3-providers-http';
 import WebsocketProvider from 'web3-providers-ws';
-import IpcProvider from 'web3-providers-ipc';
-import { Unit } from 'web3-utils';
-import { ContractSendMethod, Contract } from 'web3-eth-contract';
-import { Socket } from 'net';
+import { EtherUnits } from 'web3-utils';
+import { Contract } from 'web3-eth-contract';
+import { Web3Subscription, Web3EventMap } from 'web3-core';
 import { logError, logDebug, logWarn } from 'logger';
+
+type ResolvedReturnType<T> = T extends Promise<infer R> ? R : never;
+type GetBlockOutput = ResolvedReturnType<
+  ReturnType<typeof Web3.prototype.eth.getBlock>
+>;
+
+type GetTransactionOutput = ResolvedReturnType<
+  ReturnType<typeof Web3.prototype.eth.getTransaction>
+>;
 
 function findRootFolder(path: string): string {
   let foldersMatched = 0;
@@ -51,23 +68,30 @@ const currentWorkingDir = __dirname + '/../../../../'; //process.cwd();
 export const ROOT_PATH = findRootFolder(currentWorkingDir);
 
 export {
-  BlockHeader,
-  BlockTransactionString,
-  TransactionConfig,
+  BlockHeaderOutput,
+  GetBlockOutput,
+  GetTransactionOutput,
+  TypedTransaction,
+  Address,
+  FeeMarketEIP1559Transaction,
+  ContractAbi,
+  ContractEvents,
+  ContractConstructorArgs,
+  HexString,
+  Web3EventMap,
   pathJoin,
   readFileSync,
+  SocketConstructorOpts,
   Web3,
-  provider,
+  Web3BaseProvider,
   HttpProvider,
   IpcProvider,
   WebsocketProvider,
-  Unit,
+  EtherUnits,
   TransactionReceipt,
-  ContractSendMethod,
-  SignedTransaction,
-  Subscription,
+  SignTransactionResult,
+  Web3Subscription,
   Contract,
-  Socket,
   logError,
   logDebug,
   logWarn

--- a/server/src/libs/blockchain-communication/deps.ts
+++ b/server/src/libs/blockchain-communication/deps.ts
@@ -16,7 +16,6 @@ import {
   TypedTransaction,
   FeeMarketEIP1559Transaction
 } from 'web3-eth-accounts';
-import { Address } from 'web3-eth-accounts/lib/commonjs/tx/address';
 import { IpcProvider } from 'web3-providers-ipc';
 import HttpProvider from 'web3-providers-http';
 import WebsocketProvider from 'web3-providers-ws';
@@ -72,7 +71,6 @@ export {
   GetBlockOutput,
   GetTransactionOutput,
   TypedTransaction,
-  Address,
   FeeMarketEIP1559Transaction,
   ContractAbi,
   ContractEvents,

--- a/server/src/libs/blockchain-communication/domain/services/nodesLoader.ts
+++ b/server/src/libs/blockchain-communication/domain/services/nodesLoader.ts
@@ -7,7 +7,7 @@ import { NodeOptions } from '../entities/nodeOptions';
 import { logWarn } from '../../deps';
 
 export function loadNodes(
-  chainId: number,
+  chainId: string,
   nodesConfigRepository: NodesConfigRepository,
   nodesRepository: NodesRepository,
   refreshNodes = false

--- a/server/src/libs/blockchain-communication/driven/repositories/nodesConfigRepository.ts
+++ b/server/src/libs/blockchain-communication/driven/repositories/nodesConfigRepository.ts
@@ -2,8 +2,8 @@ import { NodeAuth } from '../../domain/entities/nodeAuth';
 import { NodeOptions } from '../../domain/entities/nodeOptions';
 
 export interface NodesConfigRepository {
-  getNodesOptions(chainId: number): NodeOptions[];
-  getNodesAuth(chainId: number): NodeAuth[];
+  getNodesOptions(chainId: string): NodeOptions[];
+  getNodesAuth(chainId: string): NodeAuth[];
 
   callOnChange(callback: () => void): void;
   disableCallOnChange(): void;

--- a/server/src/libs/blockchain-communication/driven/repositories/nodesRepository.ts
+++ b/server/src/libs/blockchain-communication/driven/repositories/nodesRepository.ts
@@ -1,13 +1,13 @@
 import { Node } from '../../domain/entities/node';
 
 export interface NodesRepository {
-  getNodes(chainId: number): Node[];
+  getNodes(chainId: string): Node[];
 
-  save(chainId: number, node: Node): void;
+  save(chainId: string, node: Node): void;
 
-  saveAll(chainId: number, nodes: Node[]): void;
+  saveAll(chainId: string, nodes: Node[]): void;
 
-  deleteById(chainId: number, id: number): Node;
+  deleteById(chainId: string, id: number): Node;
 
-  deleteAll(chainId: number): void;
+  deleteAll(chainId: string): void;
 }

--- a/server/src/libs/blockchain-communication/mod.ts
+++ b/server/src/libs/blockchain-communication/mod.ts
@@ -14,18 +14,22 @@ export { NodeAuth } from './domain/entities/nodeAuth';
 export { Node } from './domain/entities/node';
 export { NonceTracker, getNonceTracker } from './domain/services/nonceTracker';
 export { nodeToProvider } from './domain/services/providerService';
-export { Web3 } from './deps';
+export { Web3, Address, FeeMarketEIP1559Transaction } from './deps';
 export type {
-  BlockHeader,
-  BlockTransactionString,
-  TransactionConfig,
-  Subscription,
-  Unit,
+  BlockHeaderOutput,
+  GetBlockOutput,
+  GetTransactionOutput,
+  TypedTransaction,
+  ContractAbi,
+  ContractEvents,
+  ContractConstructorArgs,
+  HexString,
+  Web3EventMap,
+  Web3Subscription,
+  EtherUnits,
   TransactionReceipt,
-  ContractSendMethod,
-  SignedTransaction,
+  SignTransactionResult,
   Contract,
-  Socket,
-  provider
+  Web3BaseProvider
 } from './deps';
 export { attemptImport } from './utils/import';

--- a/server/src/libs/blockchain-communication/mod.ts
+++ b/server/src/libs/blockchain-communication/mod.ts
@@ -14,7 +14,7 @@ export { NodeAuth } from './domain/entities/nodeAuth';
 export { Node } from './domain/entities/node';
 export { NonceTracker, getNonceTracker } from './domain/services/nonceTracker';
 export { nodeToProvider } from './domain/services/providerService';
-export { Web3, Address, FeeMarketEIP1559Transaction } from './deps';
+export { Web3, FeeMarketEIP1559Transaction } from './deps';
 export type {
   BlockHeaderOutput,
   GetBlockOutput,

--- a/server/src/libs/blockchain-communication/package.json
+++ b/server/src/libs/blockchain-communication/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "logger": "file:../logger",
     "server": "file:../../..",
-    "web3": "^1.10.0"
+    "web3": "^4.0.3"
   }
 }

--- a/server/src/libs/blockchain-communication/package.json
+++ b/server/src/libs/blockchain-communication/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "logger": "file:../logger",
     "server": "file:../../..",
-    "web3": "^4.0.3"
+    "web3": "^4.1.0"
   }
 }

--- a/server/src/libs/blockchain-communication/utils/import.ts
+++ b/server/src/libs/blockchain-communication/utils/import.ts
@@ -9,7 +9,10 @@ export async function attemptImport(
   try {
     imported = await import(path);
   } catch (e) {
-    logWarn(JSON.stringify(e));
+    logWarn('Error while attemptImport', JSON.stringify(e));
+    if (e instanceof Error) {
+      logWarn('attemptImport error msg:', e.message);
+    }
     imported = fallbackImport;
   }
 

--- a/server/src/libs/worker-pool/workerPool.ts
+++ b/server/src/libs/worker-pool/workerPool.ts
@@ -88,6 +88,7 @@ export class WorkerPool extends EventEmitter {
       }
 
       // Delete worker and create a new one
+      worker.worker.removeAllListeners();
       this.workers.splice(this.workers.indexOf(worker), 1);
       this.addWorker();
     });

--- a/server/src/mod.ts
+++ b/server/src/mod.ts
@@ -36,7 +36,8 @@ export {
 } from './chains/domain/services/blocksService';
 export {
   getGasWrappedTokenAddress,
-  getNativeTokenSymbol
+  getNativeTokenSymbol,
+  getMempoolBlockAge
 } from './chains/domain/services/chainsService';
 export { decodeInput } from './chains/domain/services/decodeInputService';
 export { DecodedInput } from './chains/domain/entities/transaction';
@@ -47,16 +48,16 @@ export {
 export {
   Web3,
   Web3Extension,
-  Unit as EthereUnit,
+  EtherUnits,
   TransactionReceipt,
-  ContractSendMethod,
   Contract,
   Transaction,
-  SignedTransaction,
+  SignTransactionResult,
   BN,
   WorkerPool,
   WorkerTask,
-  BlockHeader,
+  BlockHeaderOutput,
+  GetTransactionOutput,
   Node,
   nodeToProvider,
   wrapWithLogger,
@@ -66,7 +67,9 @@ export {
   logError,
   LoggerOptions,
   LoggerOutputType,
-  EventData
+  EventLog,
+  ContractAbi,
+  ContractEvents
 } from './deps';
 export {
   readJsonFile,

--- a/server/src/node-providers/driven/data-sources/nodesConfigFileAdapter.ts
+++ b/server/src/node-providers/driven/data-sources/nodesConfigFileAdapter.ts
@@ -18,12 +18,12 @@ import { unwatchFile, watchFile } from '../../../utils/filesystemWatcher';
 import { Dictionary } from '../../../types/types';
 
 type NodesOptionsByChainId = {
-  chainId: number;
+  chainId: string;
   nodesOptions: NodeOptions[];
 };
 
 type NodesAuthsByChainId = {
-  chainId: number;
+  chainId: string;
   nodesAuths: NodeAuth[];
 };
 
@@ -44,7 +44,7 @@ export class NodesConfigFileAdapter implements NodesConfigRepository {
     return NodesConfigFileAdapter.instance;
   }
 
-  getNodesOptions(chainId: number): NodeOptions[] {
+  getNodesOptions(chainId: string): NodeOptions[] {
     try {
       const nodesOptionsByChainId = getObjFromJson(
         BLOCKCHAIN_COMMUNICATION_NODES_OPTIONS_ENV_KEY,
@@ -65,7 +65,7 @@ export class NodesConfigFileAdapter implements NodesConfigRepository {
     return [];
   }
 
-  getNodesAuth(chainId: number): NodeAuth[] {
+  getNodesAuth(chainId: string): NodeAuth[] {
     try {
       const nodesAuthsByChainId = getObjFromJson(
         BLOCKCHAIN_COMMUNICATION_NODES_AUTH_ENV_KEY,

--- a/server/src/node-providers/driven/data-sources/nodesMemoryAdapter.ts
+++ b/server/src/node-providers/driven/data-sources/nodesMemoryAdapter.ts
@@ -18,7 +18,7 @@ export class NodesMemoryAdapter implements NodesRepository {
     return NodesMemoryAdapter.instance;
   }
 
-  getNodes(chainId: number): Node[] {
+  getNodes(chainId: string): Node[] {
     const res = [];
     const nodes = this.nodesByChainId[chainId] || {};
     for (const key in nodes) {
@@ -28,7 +28,7 @@ export class NodesMemoryAdapter implements NodesRepository {
     return res;
   }
 
-  save(chainId: number, node: Node): void {
+  save(chainId: string, node: Node): void {
     let nodes = this.nodesByChainId[chainId];
 
     if (nodes == null) {
@@ -39,11 +39,11 @@ export class NodesMemoryAdapter implements NodesRepository {
     nodes[node.id] = node;
   }
 
-  saveAll(chainId: number, nodes: Node[]): void {
+  saveAll(chainId: string, nodes: Node[]): void {
     nodes.forEach((node) => this.save(chainId, node));
   }
 
-  deleteById(chainId: number, id: number): Node {
+  deleteById(chainId: string, id: number): Node {
     const nodes = this.nodesByChainId[chainId];
 
     if (nodes == null) {
@@ -64,7 +64,7 @@ export class NodesMemoryAdapter implements NodesRepository {
     return res;
   }
 
-  deleteAll(chainId: number): void {
+  deleteAll(chainId: string): void {
     this.nodesByChainId[chainId] = {};
   }
 }

--- a/server/src/subscribers/domain/services/subscriptionService.ts
+++ b/server/src/subscribers/domain/services/subscriptionService.ts
@@ -52,6 +52,7 @@ export const subscribeLatestBlock = (
           });
           subscription.on('error', (error: Error) => {
             if (!connected) {
+              subscription.unsubscribe();
               reject(error);
             } else if (errorHandler != null) {
               errorHandler(error);
@@ -62,6 +63,7 @@ export const subscribeLatestBlock = (
 
           // since connected not being triggered, need to resolve promise
           if (subscription.id == null) {
+            subscription.unsubscribe();
             reject(
               'subscription to latest block does not have an id, cannot proceed'
             );

--- a/server/src/subscribers/domain/services/subscriptionService.ts
+++ b/server/src/subscribers/domain/services/subscriptionService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { Dictionary } from 'src/types/types';
+import { Dictionary } from '../../../types/types';
 import {
   logDebug,
   logWarn,

--- a/server/src/utils/typeGuards.ts
+++ b/server/src/utils/typeGuards.ts
@@ -1,4 +1,4 @@
-import { logWarn, Unit } from '../deps';
+import { logWarn, EtherUnits } from '../deps';
 
 export function isType<T>(
   obj: any,
@@ -28,7 +28,7 @@ export function isType<T>(
   );
 }
 
-export function isOfEthereUnitType(value: string): value is Unit {
+export function isOfEthereUnitType(value: string): value is EtherUnits {
   return [
     'noether',
     'wei',

--- a/server/src/wallets/domain/entities/allowances.ts
+++ b/server/src/wallets/domain/entities/allowances.ts
@@ -1,8 +1,8 @@
 export type TokenAllowance = {
-  tokenAddress: string;
-  amount: string;
-  toAddress: string;
-  block: number;
+  tokenAddress: string | undefined;
+  amount: string | undefined;
+  toAddress: string | undefined;
+  block: bigint;
 };
 
 export type TokenAllowances = {

--- a/server/src/wallets/domain/entities/tokens.ts
+++ b/server/src/wallets/domain/entities/tokens.ts
@@ -1,0 +1,51 @@
+
+export type Erc20Abi = [
+  {
+    inputs: [
+      {
+        internalType: 'address';
+        name: 'spender';
+        type: 'address';
+      },
+      {
+        internalType: 'uint256';
+        name: 'amount';
+        type: 'uint256';
+      }
+    ];
+    name: 'approve';
+    outputs: [
+      {
+        internalType: 'bool';
+        name: '';
+        type: 'bool';
+      }
+    ];
+    stateMutability: 'nonpayable';
+    type: 'function';
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address';
+        name: 'owner';
+        type: 'address';
+      },
+      {
+        internalType: 'address';
+        name: 'spender';
+        type: 'address';
+      }
+    ];
+    name: 'allowance';
+    outputs: [
+      {
+        internalType: 'uint256';
+        name: '';
+        type: 'uint256';
+      }
+    ];
+    stateMutability: 'view';
+    type: 'function';
+  }
+];

--- a/server/src/wallets/domain/services/accountsService.ts
+++ b/server/src/wallets/domain/services/accountsService.ts
@@ -3,7 +3,7 @@ import { Account } from '../entities/accounts';
 import AccountNotFoundError from './errors/accountNotFoundError';
 
 export const getAccountByAccountAddress = (
-  chainId: number,
+  chainId: string,
   address: string
 ): Account => {
   const account = getAccountsRepository().getAccount(chainId, address);
@@ -13,5 +13,5 @@ export const getAccountByAccountAddress = (
   return account;
 };
 
-export const getAccounts = (chainId: number): Account[] =>
+export const getAccounts = (chainId: string): Account[] =>
   getAccountsRepository().getAccounts(chainId);

--- a/server/src/wallets/domain/services/errors/accountNotFoundError.ts
+++ b/server/src/wallets/domain/services/errors/accountNotFoundError.ts
@@ -1,5 +1,5 @@
 class AccountNotFoundError extends Error {
-  constructor(chainId: number, address: string) {
+  constructor(chainId: string, address: string) {
     super(
       `Could not find account in chain ${chainId} with address: ${address}.`
     );

--- a/server/src/wallets/driven/data-sources/accountsConfigFileAdapter.ts
+++ b/server/src/wallets/driven/data-sources/accountsConfigFileAdapter.ts
@@ -8,7 +8,7 @@ import NoAccountsProvidedError from './errors/noAccountsProvidedError';
 import { isType } from '../../../utils/typeGuards';
 
 type AccountsByChainId = {
-  chainId: number;
+  chainId: string;
   accounts: Account[];
 };
 
@@ -32,7 +32,7 @@ export class AccountsConfigFileAdapter implements AccountsRepository {
     return AccountsConfigFileAdapter.instance;
   }
 
-  getAccounts(chainId: number): Account[] {
+  getAccounts(chainId: string): Account[] {
     try {
       if (this._refreshAccounts) {
         try {
@@ -74,7 +74,7 @@ export class AccountsConfigFileAdapter implements AccountsRepository {
     return [];
   }
 
-  getAccount(chainId: number, address: string): Account | undefined {
+  getAccount(chainId: string, address: string): Account | undefined {
     return this._accounts
       .find((accountsByChainId) => accountsByChainId.chainId === chainId)
       ?.accounts.find((acc) => acc.address === address);

--- a/server/src/wallets/driven/repositories/accountsRepository.ts
+++ b/server/src/wallets/driven/repositories/accountsRepository.ts
@@ -1,6 +1,6 @@
 import { Account } from '../../domain/entities/accounts';
 
 export interface AccountsRepository {
-  getAccounts(chainId: number): Account[];
-  getAccount(chainId: number, address: string): Account | undefined;
+  getAccounts(chainId: string): Account[];
+  getAccount(chainId: string, address: string): Account | undefined;
 }

--- a/server/src/wallets/drivers/walletsCliAdapter.ts
+++ b/server/src/wallets/drivers/walletsCliAdapter.ts
@@ -1,4 +1,5 @@
 import {
+  BN,
   cliAdapter,
   cliEntrypoint,
   getAllCliEntrypointsByCliAdapter,
@@ -55,7 +56,7 @@ export class WalletsCliAdapter {
     description: WalletsCliConstants.ALLOWANCE_LIST_TOKENS_DESCRIPTION
   })
   async listTokensAllowances(
-    chainId: number,
+    chainId: string,
     ownerAddress: string,
     nDays: number
   ): Promise<void> {
@@ -94,7 +95,7 @@ export class WalletsCliAdapter {
     description: WalletsCliConstants.ALLOWANCE_APPROVE_TOKEN_DESCRIPTION
   })
   async approveTokenAllowance(
-    chainId: number,
+    chainId: string,
     tokenAddress: string,
     ownerAddress: string,
     spenderAddress: string,
@@ -109,7 +110,7 @@ export class WalletsCliAdapter {
         getAccountByAccountAddress(chainId, ownerAddress),
         tokenAddress,
         spenderAddress,
-        web3.utils.toBN(amount),
+        new BN(amount),
         isWeth
       );
     } catch (e) {
@@ -122,7 +123,7 @@ export class WalletsCliAdapter {
     description: WalletsCliConstants.ALLOWANCE_REVOKE_TOKEN_DESCRIPTION
   })
   async revokeTokenAllowance(
-    chainId: number,
+    chainId: string,
     tokenAddress: string,
     ownerAddress: string,
     spenderAddress: string,
@@ -136,7 +137,7 @@ export class WalletsCliAdapter {
         getAccountByAccountAddress(chainId, ownerAddress),
         tokenAddress,
         spenderAddress,
-        web3.utils.toBN(0),
+        new BN(0),
         isWeth
       );
     } catch (e) {


### PR DESCRIPTION
- Upgrades web3js lib to v4. Migrates Web3 providers in blockchain-comm
unication. Starts supporting bigint instead of number in some web3 functions in blockchai-communication.
- Updates blockchain-communication dependency in server. Upgrades some numbers to big ints.
- Migrates signTransaction and sendTransaction call. Replaces chainId type from number to bigint.
- Migrates Contract instantiation to support having an Abi type. Migrates subscribe. Migrates other missing parts.
- Changes gas relativa vars to bigint
- Changes chainId type to string in most places
- Updates web3js dependency to 4.1.0. Specifies chainId at Dockerfile level (needed due to an issue). 
- Updates register subscription for newBlocks and pendingTransactions to resolve promise instead of waiting for connected event (since it should be called, but its not happening).
- Fixes issues in sendTransaction